### PR TITLE
Add purchase and stock management

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -3,10 +3,10 @@
 {
     'name': 'Modulo de ropAlmi',
     'version': '1.0',
-    'depends' : ['base','contacts','mail'],
+    'depends' : ['base','contacts','mail', 'stock'],
     'author' : 'Almi',
     'category': 'RopAlmi',
     'website': '',
-    'description': 'Modulo para gestionar ropas',
+    'description': 'Modulo para gestionar ropas, compras y gestión de stock',
 
 }

--- a/models/purchase.py
+++ b/models/purchase.py
@@ -1,0 +1,9 @@
+from odoo import models, fields, api
+
+class PurchaseOrder(models.Model):
+    _name = 'purchase.order'
+    _description = 'Purchase Order'
+
+    order_date = fields.Date(string='Order Date', required=True)
+    supplier = fields.Many2one('res.partner', string='Supplier', required=True)
+    total_amount = fields.Float(string='Total Amount', required=True)

--- a/models/stock.py
+++ b/models/stock.py
@@ -1,0 +1,9 @@
+from odoo import models, fields, api
+
+class StockItem(models.Model):
+    _name = 'stock.item'
+    _description = 'Stock Item'
+
+    item_name = fields.Char(string='Item Name', required=True)
+    quantity = fields.Integer(string='Quantity', required=True)
+    location = fields.Char(string='Location', required=True)

--- a/views/menu.xml
+++ b/views/menu.xml
@@ -1,0 +1,4 @@
+<odoo>
+    <menuitem id="menu_purchases" name="Purchases" parent="base.menu_custom" sequence="10"/>
+    <menuitem id="menu_stock_management" name="Stock Management" parent="base.menu_custom" sequence="20"/>
+</odoo>


### PR DESCRIPTION
Add functionality for managing company operations such as purchases and stock management.

* **`__init__.py`**
  - Import the `models` module.

* **`__manifest__.py`**
  - Add `stock` to the `depends` list.
  - Update the `description` to include purchases and stock management.

* **`views/menu.xml`**
  - Add a menu item for `Purchases`.
  - Add a menu item for `Stock Management`.

* **`models/purchase.py`**
  - Define a model for `PurchaseOrder`.
  - Add fields for `order_date`, `supplier`, and `total_amount`.

* **`models/stock.py`**
  - Define a model for `StockItem`.
  - Add fields for `item_name`, `quantity`, and `location`.

